### PR TITLE
Feature/add boundary perms

### DIFF
--- a/src/cfn-custom-resources/lambda-code-update/index.ts
+++ b/src/cfn-custom-resources/lambda-code-update/index.ts
@@ -30,7 +30,7 @@ async function updateLambdaCode(
   console.log(
     `Adding configuration to Lambda function ${lambdaFunction}:\n${stringifiedConfig}`
   );
-  // Parse the JSON to ensure it's validity (and avoid ugly errors at runtime)
+  // Parse the JSON to ensure its validity (and avoid ugly errors at runtime)
   const config = JSON.parse(stringifiedConfig);
   // Fetch and extract Lambda zip contents to temporary folder, add configuration.json, and rezip
   const { Code } = await LAMBDA_CLIENT.getFunction({

--- a/template.yaml
+++ b/template.yaml
@@ -1,5 +1,6 @@
 # Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
+# aws-adfs login --profile="otp-prod"
 # sam package --template-file template.yaml --output-template-file packaged.yaml --s3-bucket cloudfront-authorization-at-edge-centrica --profile "otp-prod"
 # sam publish --template packaged.yaml --region eu-west-2 --profile "otp-prod"
 
@@ -29,7 +30,7 @@ Metadata:
         "amplify",
       ]
     HomePageUrl: https://github.com/centrica-engineering
-    SemanticVersion: 2.0.5-alpha1
+    SemanticVersion: 2.0.5-alpha7
     SourceCodeUrl: https://github.com/centrica-engineering/cloudfront-authorization-at-edge
 
 Parameters:
@@ -139,11 +140,12 @@ Parameters:
       - "error"
       - "debug"
   PermissionBoundaryPolicyArn:
-    Description: ARN to a boundary policy if your organisation uses some for roles, optional
+    Description: ARN to a boundary policy if your organisation uses some for roles, optional. TODO find a way around not being able to pass dynamic values DefaultPermissionBoundaryPolicy.Arn
     Type: String
-    Default: DefaultPermissionBoundaryPolicy
+    Default: "true"
 
 Conditions:
+  CreateDefaultBoundaryPolicy: !Equals [!Ref PermissionBoundaryPolicyArn, "true"]
   CreateUser: !And
     - !Not [!Equals [!Ref EmailAddress, ""]]
     - !Equals [!Ref UserPoolArn, ""]
@@ -227,6 +229,7 @@ Resources:
 
   DefaultPermissionBoundaryPolicy:
     Type: AWS::IAM::ManagedPolicy
+    Condition: CreateDefaultBoundaryPolicy
     Properties:
       Description: "non-restrictive default permission boundary, used only if no separate PermissionBoundaryPolicyArn is used"
       PolicyDocument:
@@ -419,22 +422,45 @@ Resources:
         - !GetAtt UserPool.Arn
         - !Ref UserPoolArn
 
+  UserPoolDomainLookupHandlerRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: "2012-10-17"
+      ManagedPolicyArns:
+        - Fn::Sub: 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+      PermissionsBoundary: !Ref PermissionBoundaryPolicyArn
+  UserPoolDomainLookupHandlerPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - cognito-idp:DescribeUserPool
+            Resource: !If
+              - CreateUserPoolAndClient
+              - !GetAtt UserPool.Arn
+              - !Ref UserPoolArn
+      PolicyName: UserPoolDomainLookupHandlerPolicy
+      Roles:
+        - Ref: UserPoolDomainLookupHandlerRole
   UserPoolDomainLookupHandler:
     Type: AWS::Serverless::Function
     Properties:
       CodeUri: src/cfn-custom-resources/user-pool-domain/
       Handler: index.handler
       Runtime: nodejs12.x
-      Policies:
-        - Version: "2012-10-17"
-          Statement:
-            - Effect: Allow
-              Action:
-                - cognito-idp:DescribeUserPool
-              Resource: !If
-                - CreateUserPoolAndClient
-                - !GetAtt UserPool.Arn
-                - !Ref UserPoolArn
+      Role: !Ref UserPoolDomainLookupHandlerRole
+    DependsOn:
+      - UserPoolDomainLookupHandlerRole
+      - UserPoolDomainLookupHandlerPolicy
 
   UserPoolClientUpdate:
     Type: Custom::UserPoolClientUpdate
@@ -458,20 +484,43 @@ Resources:
       AlternateDomainNames: !Ref AlternateDomainNames
       OAuthScopes: !Ref OAuthScopes
 
+  UserPoolClientUpdateHandlerServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: "2012-10-17"
+      ManagedPolicyArns:
+        - Fn::Sub: 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+      PermissionsBoundary: !Ref PermissionBoundaryPolicyArn
+  UserPoolClientUpdateHandlerPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - cognito-idp:UpdateUserPoolClient
+              - cognito-idp:DescribeUserPoolClient
+            Resource: "*"  # * to be able to clean up after myself, if you change the User Pool Client ID
+      PolicyName: UserPoolClientUpdateHandlerPolicy
+      Roles:
+        - Ref: UserPoolClientUpdateHandlerServiceRole
   UserPoolClientUpdateHandler:
     Type: AWS::Serverless::Function
     Properties:
       CodeUri: src/cfn-custom-resources/user-pool-client/
       Handler: index.handler
       Runtime: nodejs12.x
-      Policies:
-        - Version: "2012-10-17"
-          Statement:
-            - Effect: Allow
-              Action:
-                - cognito-idp:UpdateUserPoolClient
-                - cognito-idp:DescribeUserPoolClient
-              Resource: "*"  # * to be able to clean up after myself, if you change the User Pool Client ID
+      Role: !GetAtt UserPoolClientUpdateHandlerServiceRole.Arn
+    DependsOn:
+      - UserPoolClientUpdateHandlerServiceRole
+      - UserPoolClientUpdateHandlerPolicy
 
   ClientSecretRetrieval:
     Type: Custom::ClientSecretRetrieval
@@ -487,6 +536,35 @@ Resources:
         - !Ref UserPoolClient
         - !Ref UserPoolClientId
 
+  ClientSecretRetrievalHandlerRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: "2012-10-17"
+      ManagedPolicyArns:
+        - Fn::Sub: 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+      PermissionsBoundary: !Ref PermissionBoundaryPolicyArn
+  ClientSecretRetrievalHandlerPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - cognito-idp:DescribeUserPoolClient
+            Resource: !If
+              - CreateUserPoolAndClient
+              - !GetAtt UserPool.Arn
+              - !Ref UserPoolArn
+      PolicyName: ClientSecretRetrievalHandlerPolicy
+      Roles:
+        - Ref: ClientSecretRetrievalHandlerRole
   ClientSecretRetrievalHandler:
     Type: AWS::Serverless::Function
     Condition: StaticSiteMode
@@ -494,16 +572,10 @@ Resources:
       CodeUri: src/cfn-custom-resources/client-secret-retrieval/
       Handler: index.handler
       Runtime: nodejs12.x
-      Policies:
-        - Version: "2012-10-17"
-          Statement:
-            - Effect: Allow
-              Action:
-                - cognito-idp:DescribeUserPoolClient
-              Resource: !If
-                - CreateUserPoolAndClient
-                - !GetAtt UserPool.Arn
-                - !Ref UserPoolArn
+      Role: !GetAtt ClientSecretRetrievalHandlerRole.Arn
+    DependsOn:
+      - ClientSecretRetrievalHandlerRole
+      - ClientSecretRetrievalHandlerPolicy
 
   StaticSite:
     Type: Custom::StaticSite
@@ -512,6 +584,40 @@ Resources:
       ServiceToken: !GetAtt StaticSiteHandler.Arn
       BucketName: !Ref S3Bucket
 
+  StaticSiteHandlerRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: "2012-10-17"
+      ManagedPolicyArns:
+        - Fn::Sub: 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+      PermissionsBoundary: !Ref PermissionBoundaryPolicyArn
+  StaticSiteHandlerPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - s3:ListBucket
+            Resource:
+              - !GetAtt S3Bucket.Arn
+          - Effect: Allow
+            Action:
+              - s3:DeleteObject
+              - s3:PutObject
+            Resource:
+              - !GetAtt S3Bucket.Arn
+              - !Join ["/", [!GetAtt S3Bucket.Arn, "*"]]
+      PolicyName: StaticSiteHandlerPolicy
+      Roles:
+        - Ref: StaticSiteHandlerRole
   StaticSiteHandler:
     Type: AWS::Serverless::Function
     Condition: CreateCloudFrontDistributionStaticSiteMode
@@ -521,21 +627,10 @@ Resources:
       Runtime: nodejs12.x
       Timeout: 180
       MemorySize: 2048
-      Policies:
-        - Version: "2012-10-17"
-          Statement:
-            - Effect: Allow
-              Action:
-                - s3:ListBucket
-              Resource:
-                - !GetAtt S3Bucket.Arn
-            - Effect: Allow
-              Action:
-                - s3:DeleteObject
-                - s3:PutObject
-              Resource:
-                - !GetAtt S3Bucket.Arn
-                - !Join ["/", [!GetAtt S3Bucket.Arn, "*"]]
+      Role: !GetAtt StaticSiteHandlerRole.Arn
+    DependsOn:
+      - StaticSiteHandlerRole
+      - StaticSiteHandlerPolicy
 
   ReactApp:
     Type: Custom::ReactApp
@@ -559,6 +654,40 @@ Resources:
         - !Ref OAuthScopes
       SignOutUrl: !Ref SignOutUrl
 
+  ReactAppHandlerRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: "2012-10-17"
+      ManagedPolicyArns:
+        - Fn::Sub: 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+      PermissionsBoundary: !Ref PermissionBoundaryPolicyArn
+  ReactAppHandlerPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - s3:ListBucket
+            Resource:
+              - !GetAtt S3Bucket.Arn
+          - Effect: Allow
+            Action:
+              - s3:DeleteObject
+              - s3:PutObject
+            Resource:
+              - !GetAtt S3Bucket.Arn
+              - !Join ["/", [!GetAtt S3Bucket.Arn, "*"]]
+      PolicyName: ReactAppHandlerPolicy
+      Roles:
+        - Ref: ReactAppHandlerRole
   ReactAppHandler:
     Type: AWS::Serverless::Function
     Condition: CreateCloudFrontDistributionSpaMode
@@ -568,21 +697,10 @@ Resources:
       Runtime: nodejs12.x
       Timeout: 300
       MemorySize: 3008
-      Policies:
-        - Version: "2012-10-17"
-          Statement:
-            - Effect: Allow
-              Action:
-                - s3:ListBucket
-              Resource:
-                - !GetAtt S3Bucket.Arn
-            - Effect: Allow
-              Action:
-                - s3:DeleteObject
-                - s3:PutObject
-              Resource:
-                - !GetAtt S3Bucket.Arn
-                - !Join ["/", [!GetAtt S3Bucket.Arn, "*"]]
+      Role: !GetAtt ReactAppHandlerRole.Arn
+    DependsOn:
+      - ReactAppHandlerRole
+      - ReactAppHandlerPolicy
 
   ParseAuthHandlerCodeUpdate:
     Type: Custom::LambdaCodeUpdate
@@ -801,25 +919,48 @@ Resources:
                   - !Ref OAuthScopes
                 - '"]'
 
+  LambdaCodeUpdateHandlerRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: "2012-10-17"
+      ManagedPolicyArns:
+        - Fn::Sub: 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+      PermissionsBoundary: !Ref PermissionBoundaryPolicyArn
+  LambdaCodeUpdateHandlerPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - lambda:GetFunction
+              - lambda:UpdateFunctionCode
+            Resource:
+              - !GetAtt ParseAuthHandler.Arn
+              - !GetAtt CheckAuthHandler.Arn
+              - !GetAtt HttpHeadersHandler.Arn
+              - !GetAtt RefreshAuthHandler.Arn
+              - !GetAtt SignOutHandler.Arn
+      PolicyName: LambdaCodeUpdateHandlerPolicy
+      Roles:
+        - Ref: LambdaCodeUpdateHandlerRole
   LambdaCodeUpdateHandler:
     Type: AWS::Serverless::Function
     Properties:
       CodeUri: src/cfn-custom-resources/lambda-code-update/
       Handler: index.handler
       Runtime: nodejs12.x
-      Policies:
-        - Version: "2012-10-17"
-          Statement:
-            - Effect: Allow
-              Action:
-                - lambda:GetFunction
-                - lambda:UpdateFunctionCode
-              Resource:
-                - !GetAtt ParseAuthHandler.Arn
-                - !GetAtt CheckAuthHandler.Arn
-                - !GetAtt HttpHeadersHandler.Arn
-                - !GetAtt RefreshAuthHandler.Arn
-                - !GetAtt SignOutHandler.Arn
+      Role: !GetAtt LambdaCodeUpdateHandlerRole.Arn
+    DependsOn:
+      - LambdaCodeUpdateHandlerRole
+      - LambdaCodeUpdateHandlerPolicy
 
   NonceSigningSecret:
     Type: Custom::NonceSigningSecret
@@ -828,12 +969,28 @@ Resources:
       Length: 16
       Version: !Ref Version
 
+  RandomValueGeneratorServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: "2012-10-17"
+      ManagedPolicyArns:
+        - Fn::Sub: 'arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+      PermissionsBoundary: !Ref PermissionBoundaryPolicyArn
   RandomValueGenerator:
     Type: AWS::Serverless::Function
     Properties:
       CodeUri: src/cfn-custom-resources/generate-secret/
       Handler: index.handler
       Runtime: nodejs12.x
+      Role: !GetAtt RandomValueGeneratorServiceRole.Arn
+    DependsOn:
+      - RandomValueGeneratorServiceRole
 
 Outputs:
   S3Bucket:

--- a/template.yaml
+++ b/template.yaml
@@ -1,5 +1,7 @@
 # Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
+# sam package --template-file template.yaml --output-template-file packaged.yaml --s3-bucket cloudfront-authorization-at-edge-centrica --profile "otp-prod"
+# sam publish --template packaged.yaml --region eu-west-2 --profile "otp-prod"
 
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
@@ -226,13 +228,14 @@ Resources:
   DefaultPermissionBoundaryPolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
+      Description: "non-restrictive default permission boundary, used only if no separate PermissionBoundaryPolicyArn is used"
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
           - Effect: Allow
             Action: '*'
             Resource: '*'
-      PolicyName: DefaultPermissionBoundaryPolicy
+      ManagedPolicyName: DefaultPermissionBoundaryPolicy
   LambdaEdgeExecutionRole:
     Type: AWS::IAM::Role
     Properties:

--- a/template.yaml
+++ b/template.yaml
@@ -34,7 +34,7 @@ Metadata:
         "amplify",
       ]
     HomePageUrl: https://github.com/centrica-engineering
-    SemanticVersion: 2.0.5-alpha17
+    SemanticVersion: 2.0.5-alpha18
     SourceCodeUrl: https://github.com/centrica-engineering/cloudfront-authorization-at-edge
 
 Parameters:
@@ -102,6 +102,16 @@ Parameters:
     AllowedValues:
       - "true"
       - "false"
+  CloudfrontAliases:
+    Type: CommaDelimitedList
+    Description: aka cnames
+    Default: AWS::NoValue
+  CloudFrontDefaultCertificate:
+    Type: String
+    Default: "true"
+  AcmCertificateArn:
+      Type: String
+      Default: AWS::NoValue
   CookieCompatibility:
     Type: String
     Description: "Specify whether naming of cookies should be compatible with AWS Amplify (default) or Amazon Elasticsearch Service. In case of the latter, turn off SPA mode too: set parameter EnableSPAMode to false"
@@ -268,6 +278,11 @@ Resources:
     Condition: CreateCloudFrontDistribution
     Properties:
       DistributionConfig:
+        Aliases: !Ref CloudfrontAliases
+        CloudFrontDefaultCertificate: !Ref CloudFrontDefaultCertificate
+        AcmCertificateArn: !Ref AcmCertificateArn
+        SslSupportMethod: sni-only
+        MinimumProtocolVersion: TLSv1.2_2019
         CacheBehaviors:
           - PathPattern: !Ref RedirectPathSignIn
             Compress: true

--- a/template.yaml
+++ b/template.yaml
@@ -136,6 +136,10 @@ Parameters:
       - "warn"
       - "error"
       - "debug"
+  PermissionBoundaryPolicyArn:
+    Description: ARN to a boundary policy if your organisation uses some for roles, optional
+    Type: String
+    Default: DefaultPermissionBoundaryPolicy
 
 Conditions:
   CreateUser: !And
@@ -219,6 +223,16 @@ Resources:
       Role: !GetAtt LambdaEdgeExecutionRole.Arn
       Timeout: 5
 
+  DefaultPermissionBoundaryPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action: '*'
+            Resource: '*'
+      PolicyName: DefaultPermissionBoundaryPolicy
   LambdaEdgeExecutionRole:
     Type: AWS::IAM::Role
     Properties:
@@ -234,6 +248,7 @@ Resources:
               - sts:AssumeRole
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      PermissionsBoundary: !Ref PermissionBoundaryPolicyArn
 
   CloudFrontDistribution:
     Type: AWS::CloudFront::Distribution

--- a/template.yaml
+++ b/template.yaml
@@ -30,7 +30,7 @@ Metadata:
         "amplify",
       ]
     HomePageUrl: https://github.com/centrica-engineering
-    SemanticVersion: 2.0.5-alpha8
+    SemanticVersion: 2.0.5-alpha10
     SourceCodeUrl: https://github.com/centrica-engineering/cloudfront-authorization-at-edge
 
 Parameters:
@@ -180,7 +180,7 @@ Resources:
     Type: AWS::S3::Bucket
     Condition: CreateCloudFrontDistribution
     Properties:
-      AccessControl: Public
+      AccessControl: PublicRead
 
   CheckAuthHandler:
     Type: AWS::Serverless::Function
@@ -997,8 +997,8 @@ Outputs:
     Description: The S3 Bucket where the SPA (React, Angular, Vue, ...) is uploaded to
     Condition: CreateCloudFrontDistribution
     Value: !Ref S3Bucket
-    Export:
-      Name: !Sub "${AWS::StackName}-S3Bucket"
+    #Export:
+      #Name: !Sub "${AWS::StackName}-S3Bucket"
   WebsiteUrl:
     Description: URL of the CloudFront distribution that serves your SPA from S3
     Condition: CreateCloudFrontDistribution

--- a/template.yaml
+++ b/template.yaml
@@ -27,7 +27,7 @@ Metadata:
         "amplify",
       ]
     HomePageUrl: https://github.com/centrica-engineering
-    SemanticVersion: 2.0.5-alpha
+    SemanticVersion: 2.0.5-alpha1
     SourceCodeUrl: https://github.com/centrica-engineering/cloudfront-authorization-at-edge
 
 Parameters:
@@ -224,7 +224,7 @@ Resources:
       Timeout: 5
 
   DefaultPermissionBoundaryPolicy:
-    Type: AWS::IAM::Policy
+    Type: AWS::IAM::ManagedPolicy
     Properties:
       PolicyDocument:
         Version: "2012-10-17"

--- a/template.yaml
+++ b/template.yaml
@@ -1,5 +1,9 @@
 # Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
+#
+# npm install
+# npm run build
+# sam build --use-container
 # aws-adfs login --profile="otp-prod"
 # sam package --template-file template.yaml --output-template-file packaged.yaml --s3-bucket cloudfront-authorization-at-edge-centrica --profile "otp-prod"
 # sam publish --template packaged.yaml --region eu-west-2 --profile "otp-prod"
@@ -30,7 +34,7 @@ Metadata:
         "amplify",
       ]
     HomePageUrl: https://github.com/centrica-engineering
-    SemanticVersion: 2.0.5-alpha10
+    SemanticVersion: 2.0.5-alpha17
     SourceCodeUrl: https://github.com/centrica-engineering/cloudfront-authorization-at-edge
 
 Parameters:
@@ -181,6 +185,9 @@ Resources:
     Condition: CreateCloudFrontDistribution
     Properties:
       AccessControl: PublicRead
+      WebsiteConfiguration:
+        IndexDocument: index.html
+        ErrorDocument: 404.html
 
   CheckAuthHandler:
     Type: AWS::Serverless::Function
@@ -346,6 +353,8 @@ Resources:
             Resource: !GetAtt S3Bucket.Arn
             Principal:
               CanonicalUser: !GetAtt CloudFrontOriginAccessIdentity.S3CanonicalUserId
+    DependsOn:
+      - CloudFrontOriginAccessIdentity
 
   UserPool:
     Type: AWS::Cognito::UserPool
@@ -457,7 +466,7 @@ Resources:
       CodeUri: src/cfn-custom-resources/user-pool-domain/
       Handler: index.handler
       Runtime: nodejs12.x
-      Role: !Ref UserPoolDomainLookupHandlerRole
+      Role: !GetAtt UserPoolDomainLookupHandlerRole.Arn
     DependsOn:
       - UserPoolDomainLookupHandlerRole
       - UserPoolDomainLookupHandlerPolicy
@@ -997,8 +1006,8 @@ Outputs:
     Description: The S3 Bucket where the SPA (React, Angular, Vue, ...) is uploaded to
     Condition: CreateCloudFrontDistribution
     Value: !Ref S3Bucket
-    #Export:
-      #Name: !Sub "${AWS::StackName}-S3Bucket"
+    Export:
+      Name: !Sub "${AWS::StackName}-S3Bucket"
   WebsiteUrl:
     Description: URL of the CloudFront distribution that serves your SPA from S3
     Condition: CreateCloudFrontDistribution

--- a/template.yaml
+++ b/template.yaml
@@ -26,8 +26,8 @@ Metadata:
         "vue",
         "amplify",
       ]
-    HomePageUrl: https://github.com/aws-samples/cloudfront-authorization-at-edge
-    SemanticVersion: 2.0.4
+    HomePageUrl: https://github.com/centrica-engineering
+    SemanticVersion: 2.0.5-alpha
     SourceCodeUrl: https://github.com/centrica-engineering/cloudfront-authorization-at-edge
 
 Parameters:

--- a/template.yaml
+++ b/template.yaml
@@ -34,7 +34,7 @@ Metadata:
         "amplify",
       ]
     HomePageUrl: https://github.com/centrica-engineering
-    SemanticVersion: 2.0.5-alpha18
+    SemanticVersion: 2.0.5-alpha17
     SourceCodeUrl: https://github.com/centrica-engineering/cloudfront-authorization-at-edge
 
 Parameters:
@@ -102,16 +102,6 @@ Parameters:
     AllowedValues:
       - "true"
       - "false"
-  CloudfrontAliases:
-    Type: CommaDelimitedList
-    Description: aka cnames
-    Default: AWS::NoValue
-  CloudFrontDefaultCertificate:
-    Type: String
-    Default: "true"
-  AcmCertificateArn:
-      Type: String
-      Default: AWS::NoValue
   CookieCompatibility:
     Type: String
     Description: "Specify whether naming of cookies should be compatible with AWS Amplify (default) or Amazon Elasticsearch Service. In case of the latter, turn off SPA mode too: set parameter EnableSPAMode to false"
@@ -278,11 +268,6 @@ Resources:
     Condition: CreateCloudFrontDistribution
     Properties:
       DistributionConfig:
-        Aliases: !Ref CloudfrontAliases
-        CloudFrontDefaultCertificate: !Ref CloudFrontDefaultCertificate
-        AcmCertificateArn: !Ref AcmCertificateArn
-        SslSupportMethod: sni-only
-        MinimumProtocolVersion: TLSv1.2_2019
         CacheBehaviors:
           - PathPattern: !Ref RedirectPathSignIn
             Compress: true

--- a/template.yaml
+++ b/template.yaml
@@ -30,7 +30,7 @@ Metadata:
         "amplify",
       ]
     HomePageUrl: https://github.com/centrica-engineering
-    SemanticVersion: 2.0.5-alpha7
+    SemanticVersion: 2.0.5-alpha8
     SourceCodeUrl: https://github.com/centrica-engineering/cloudfront-authorization-at-edge
 
 Parameters:
@@ -180,7 +180,7 @@ Resources:
     Type: AWS::S3::Bucket
     Condition: CreateCloudFrontDistribution
     Properties:
-      AccessControl: Private
+      AccessControl: Public
 
   CheckAuthHandler:
     Type: AWS::Serverless::Function

--- a/template.yaml
+++ b/template.yaml
@@ -7,7 +7,7 @@ Description: >
   Protect downloads of your content hosted on CloudFront with Cognito authentication using Lambda@Edge
 Metadata:
   AWS::ServerlessRepo::Application:
-    Name: cloudfront-authorization-at-edge
+    Name: cloudfront-authorization-at-edge-centrica
     Description: >
       Protect downloads of your content hosted on CloudFront with Cognito authentication using Lambda@Edge.
       Includes: S3 Bucket w. sample SPA, Cognito User Pool with hosted UI set up, Lambda@Edge functions to validate JWT's and handle OAuth2 redirects.
@@ -28,7 +28,7 @@ Metadata:
       ]
     HomePageUrl: https://github.com/aws-samples/cloudfront-authorization-at-edge
     SemanticVersion: 2.0.4
-    SourceCodeUrl: https://github.com/aws-samples/cloudfront-authorization-at-edge
+    SourceCodeUrl: https://github.com/centrica-engineering/cloudfront-authorization-at-edge
 
 Parameters:
   EmailAddress:


### PR DESCRIPTION
SUPERCEDED BY https://github.com/centrica-engineering/cloudfront-authorization-at-edge/pull/2

- [x] add an optional `PermissionBoundaryPolicyArn` as variable, to be used as a boundary policy ARN for the organisations that need it
- [x] saved privately in Centrica prod OTP account's [serverless application repository](https://serverlessrepo.aws.amazon.com/applications) for now
- [ ] TODO: access control S3 bucket