### PR TITLE
use permission boundaries for lambdas

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1,5 +1,12 @@
 # Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
+#
+# npm install
+# npm run build
+# sam build --use-container
+# aws-adfs login --profile="otp-prod"
+# sam package --template-file template.yaml --output-template-file packaged.yaml --s3-bucket cloudfront-authorization-at-edge-centrica --profile "otp-prod"
+# sam publish --template packaged.yaml --region eu-west-2 --profile "otp-prod"
 
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
@@ -7,7 +14,7 @@ Description: >
   Protect downloads of your content hosted on CloudFront with Cognito authentication using Lambda@Edge
 Metadata:
   AWS::ServerlessRepo::Application:
-    Name: cloudfront-authorization-at-edge
+    Name: cloudfront-authorization-at-edge-centrica
     Description: >
       Protect downloads of your content hosted on CloudFront with Cognito authentication using Lambda@Edge.
       Includes: S3 Bucket w. sample SPA, Cognito User Pool with hosted UI set up, Lambda@Edge functions to validate JWT's and handle OAuth2 redirects.
@@ -26,9 +33,9 @@ Metadata:
         "vue",
         "amplify",
       ]
-    HomePageUrl: https://github.com/aws-samples/cloudfront-authorization-at-edge
-    SemanticVersion: 2.0.4
-    SourceCodeUrl: https://github.com/aws-samples/cloudfront-authorization-at-edge
+    HomePageUrl: https://github.com/centrica-engineering/cloudfront-authorization-at-edge
+    SemanticVersion: 2.0.5-alpha18
+    SourceCodeUrl: https://github.com/centrica-engineering/cloudfront-authorization-at-edge
 
 Parameters:
   EmailAddress:
@@ -136,8 +143,13 @@ Parameters:
       - "warn"
       - "error"
       - "debug"
+  PermissionBoundaryPolicyArn:
+    Description: ARN to a boundary policy if your organisation uses some for roles, optional. TODO find a way around not being able to pass dynamic values DefaultPermissionBoundaryPolicy.Arn
+    Type: String
+    Default: "true"
 
 Conditions:
+  CreateDefaultBoundaryPolicy: !Equals [!Ref PermissionBoundaryPolicyArn, "true"]
   CreateUser: !And
     - !Not [!Equals [!Ref EmailAddress, ""]]
     - !Equals [!Ref UserPoolArn, ""]
@@ -172,7 +184,10 @@ Resources:
     Type: AWS::S3::Bucket
     Condition: CreateCloudFrontDistribution
     Properties:
-      AccessControl: Private
+      AccessControl: PublicRead
+      WebsiteConfiguration:
+        IndexDocument: index.html
+        ErrorDocument: 404.html
 
   CheckAuthHandler:
     Type: AWS::Serverless::Function
@@ -219,6 +234,18 @@ Resources:
       Role: !GetAtt LambdaEdgeExecutionRole.Arn
       Timeout: 5
 
+  DefaultPermissionBoundaryPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Condition: CreateDefaultBoundaryPolicy
+    Properties:
+      Description: "non-restrictive default permission boundary, used only if no separate PermissionBoundaryPolicyArn is used"
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action: '*'
+            Resource: '*'
+      ManagedPolicyName: DefaultPermissionBoundaryPolicy
   LambdaEdgeExecutionRole:
     Type: AWS::IAM::Role
     Properties:
@@ -234,6 +261,7 @@ Resources:
               - sts:AssumeRole
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      PermissionsBoundary: !Ref PermissionBoundaryPolicyArn
 
   CloudFrontDistribution:
     Type: AWS::CloudFront::Distribution
@@ -407,6 +435,7 @@ Resources:
       CodeUri: src/cfn-custom-resources/user-pool-domain/
       Handler: index.handler
       Runtime: nodejs12.x
+      PermissionsBoundary: !Ref PermissionBoundaryPolicyArn
       Policies:
         - Version: "2012-10-17"
           Statement:
@@ -446,6 +475,7 @@ Resources:
       CodeUri: src/cfn-custom-resources/user-pool-client/
       Handler: index.handler
       Runtime: nodejs12.x
+      PermissionsBoundary: !Ref PermissionBoundaryPolicyArn
       Policies:
         - Version: "2012-10-17"
           Statement:
@@ -476,6 +506,7 @@ Resources:
       CodeUri: src/cfn-custom-resources/client-secret-retrieval/
       Handler: index.handler
       Runtime: nodejs12.x
+      PermissionsBoundary: !Ref PermissionBoundaryPolicyArn
       Policies:
         - Version: "2012-10-17"
           Statement:
@@ -503,6 +534,7 @@ Resources:
       Runtime: nodejs12.x
       Timeout: 180
       MemorySize: 2048
+      PermissionsBoundary: !Ref PermissionBoundaryPolicyArn
       Policies:
         - Version: "2012-10-17"
           Statement:
@@ -550,6 +582,7 @@ Resources:
       Runtime: nodejs12.x
       Timeout: 300
       MemorySize: 3008
+      PermissionsBoundary: !Ref PermissionBoundaryPolicyArn
       Policies:
         - Version: "2012-10-17"
           Statement:
@@ -789,6 +822,7 @@ Resources:
       CodeUri: src/cfn-custom-resources/lambda-code-update/
       Handler: index.handler
       Runtime: nodejs12.x
+      PermissionsBoundary: !Ref PermissionBoundaryPolicyArn
       Policies:
         - Version: "2012-10-17"
           Statement:
@@ -813,6 +847,7 @@ Resources:
   RandomValueGenerator:
     Type: AWS::Serverless::Function
     Properties:
+      PermissionsBoundary: !Ref PermissionBoundaryPolicyArn
       CodeUri: src/cfn-custom-resources/generate-secret/
       Handler: index.handler
       Runtime: nodejs12.x

--- a/template.yaml
+++ b/template.yaml
@@ -6,7 +6,7 @@
 # sam build --use-container
 # aws-adfs login --profile="otp-prod"
 # sam package --template-file template.yaml --output-template-file packaged.yaml --s3-bucket cloudfront-authorization-at-edge-centrica --profile "otp-prod"
-# sam publish --template packaged.yaml --region eu-west-2 --profile "otp-prod"
+# sam publish --template packaged.yaml --region us-east-1 --profile "otp-prod"
 
 AWSTemplateFormatVersion: "2010-09-09"
 Transform: AWS::Serverless-2016-10-31
@@ -178,6 +178,8 @@ Conditions:
 Globals:
   Function:
     Timeout: 60
+    PermissionsBoundary: !If [CreateDefaultBoundaryPolicy, !GetAtt DefaultPermissionBoundaryPolicy.Arn, !Ref PermissionBoundaryPolicyArn]
+    Runtime: nodejs12.x
 
 Resources:
   S3Bucket:
@@ -434,8 +436,8 @@ Resources:
     Properties:
       CodeUri: src/cfn-custom-resources/user-pool-domain/
       Handler: index.handler
-      Runtime: nodejs12.x
-      PermissionsBoundary: !Ref PermissionBoundaryPolicyArn
+      #Runtime: nodejs12.x
+      #PermissionsBoundary: !Ref PermissionBoundaryPolicyArn
       Policies:
         - Version: "2012-10-17"
           Statement:
@@ -474,8 +476,8 @@ Resources:
     Properties:
       CodeUri: src/cfn-custom-resources/user-pool-client/
       Handler: index.handler
-      Runtime: nodejs12.x
-      PermissionsBoundary: !Ref PermissionBoundaryPolicyArn
+      #Runtime: nodejs12.x
+      #PermissionsBoundary: !Ref PermissionBoundaryPolicyArn
       Policies:
         - Version: "2012-10-17"
           Statement:
@@ -505,8 +507,8 @@ Resources:
     Properties:
       CodeUri: src/cfn-custom-resources/client-secret-retrieval/
       Handler: index.handler
-      Runtime: nodejs12.x
-      PermissionsBoundary: !Ref PermissionBoundaryPolicyArn
+      #Runtime: nodejs12.x
+      #PermissionsBoundary: !Ref PermissionBoundaryPolicyArn
       Policies:
         - Version: "2012-10-17"
           Statement:
@@ -531,10 +533,10 @@ Resources:
     Properties:
       CodeUri: src/cfn-custom-resources/static-site/
       Handler: bundle.handler
-      Runtime: nodejs12.x
+      #Runtime: nodejs12.x
       Timeout: 180
       MemorySize: 2048
-      PermissionsBoundary: !Ref PermissionBoundaryPolicyArn
+      #PermissionsBoundary: !Ref PermissionBoundaryPolicyArn
       Policies:
         - Version: "2012-10-17"
           Statement:
@@ -579,10 +581,10 @@ Resources:
     Properties:
       CodeUri: src/cfn-custom-resources/react-app/
       Handler: bundle.handler
-      Runtime: nodejs12.x
+      #Runtime: nodejs12.x
       Timeout: 300
       MemorySize: 3008
-      PermissionsBoundary: !Ref PermissionBoundaryPolicyArn
+      #PermissionsBoundary: !Ref PermissionBoundaryPolicyArn
       Policies:
         - Version: "2012-10-17"
           Statement:
@@ -821,8 +823,8 @@ Resources:
     Properties:
       CodeUri: src/cfn-custom-resources/lambda-code-update/
       Handler: index.handler
-      Runtime: nodejs12.x
-      PermissionsBoundary: !Ref PermissionBoundaryPolicyArn
+      #Runtime: nodejs12.x
+      #PermissionsBoundary: !Ref PermissionBoundaryPolicyArn
       Policies:
         - Version: "2012-10-17"
           Statement:
@@ -847,10 +849,10 @@ Resources:
   RandomValueGenerator:
     Type: AWS::Serverless::Function
     Properties:
-      PermissionsBoundary: !Ref PermissionBoundaryPolicyArn
+      #PermissionsBoundary: !Ref PermissionBoundaryPolicyArn
       CodeUri: src/cfn-custom-resources/generate-secret/
       Handler: index.handler
-      Runtime: nodejs12.x
+      #Runtime: nodejs12.x
 
 Outputs:
   S3Bucket:

--- a/template.yaml
+++ b/template.yaml
@@ -186,10 +186,7 @@ Resources:
     Type: AWS::S3::Bucket
     Condition: CreateCloudFrontDistribution
     Properties:
-      AccessControl: PublicRead
-      WebsiteConfiguration:
-        IndexDocument: index.html
-        ErrorDocument: 404.html
+      AccessControl: Private
 
   CheckAuthHandler:
     Type: AWS::Serverless::Function
@@ -263,7 +260,7 @@ Resources:
               - sts:AssumeRole
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
-      PermissionsBoundary: !Ref PermissionBoundaryPolicyArn
+      PermissionsBoundary: !If [CreateDefaultBoundaryPolicy, !Ref DefaultPermissionBoundaryPolicy, !Ref PermissionBoundaryPolicyArn]
 
   CloudFrontDistribution:
     Type: AWS::CloudFront::Distribution
@@ -436,8 +433,6 @@ Resources:
     Properties:
       CodeUri: src/cfn-custom-resources/user-pool-domain/
       Handler: index.handler
-      #Runtime: nodejs12.x
-      #PermissionsBoundary: !Ref PermissionBoundaryPolicyArn
       Policies:
         - Version: "2012-10-17"
           Statement:
@@ -476,8 +471,6 @@ Resources:
     Properties:
       CodeUri: src/cfn-custom-resources/user-pool-client/
       Handler: index.handler
-      #Runtime: nodejs12.x
-      #PermissionsBoundary: !Ref PermissionBoundaryPolicyArn
       Policies:
         - Version: "2012-10-17"
           Statement:
@@ -507,8 +500,6 @@ Resources:
     Properties:
       CodeUri: src/cfn-custom-resources/client-secret-retrieval/
       Handler: index.handler
-      #Runtime: nodejs12.x
-      #PermissionsBoundary: !Ref PermissionBoundaryPolicyArn
       Policies:
         - Version: "2012-10-17"
           Statement:
@@ -533,10 +524,8 @@ Resources:
     Properties:
       CodeUri: src/cfn-custom-resources/static-site/
       Handler: bundle.handler
-      #Runtime: nodejs12.x
       Timeout: 180
       MemorySize: 2048
-      #PermissionsBoundary: !Ref PermissionBoundaryPolicyArn
       Policies:
         - Version: "2012-10-17"
           Statement:
@@ -581,10 +570,8 @@ Resources:
     Properties:
       CodeUri: src/cfn-custom-resources/react-app/
       Handler: bundle.handler
-      #Runtime: nodejs12.x
       Timeout: 300
       MemorySize: 3008
-      #PermissionsBoundary: !Ref PermissionBoundaryPolicyArn
       Policies:
         - Version: "2012-10-17"
           Statement:
@@ -823,8 +810,6 @@ Resources:
     Properties:
       CodeUri: src/cfn-custom-resources/lambda-code-update/
       Handler: index.handler
-      #Runtime: nodejs12.x
-      #PermissionsBoundary: !Ref PermissionBoundaryPolicyArn
       Policies:
         - Version: "2012-10-17"
           Statement:
@@ -849,10 +834,8 @@ Resources:
   RandomValueGenerator:
     Type: AWS::Serverless::Function
     Properties:
-      #PermissionsBoundary: !Ref PermissionBoundaryPolicyArn
       CodeUri: src/cfn-custom-resources/generate-secret/
       Handler: index.handler
-      #Runtime: nodejs12.x
 
 Outputs:
   S3Bucket:

--- a/template.yaml
+++ b/template.yaml
@@ -178,7 +178,7 @@ Conditions:
 Globals:
   Function:
     Timeout: 60
-    PermissionsBoundary: !If [CreateDefaultBoundaryPolicy, !GetAtt DefaultPermissionBoundaryPolicy.Arn, !Ref PermissionBoundaryPolicyArn]
+    PermissionsBoundary: !If [CreateDefaultBoundaryPolicy, !Ref DefaultPermissionBoundaryPolicy, !Ref PermissionBoundaryPolicyArn]
     Runtime: nodejs12.x
 
 Resources:

--- a/template.yaml
+++ b/template.yaml
@@ -34,7 +34,7 @@ Metadata:
         "amplify",
       ]
     HomePageUrl: https://github.com/centrica-engineering/cloudfront-authorization-at-edge
-    SemanticVersion: 2.0.5-alpha18
+    SemanticVersion: 2.0.5-alpha19
     SourceCodeUrl: https://github.com/centrica-engineering/cloudfront-authorization-at-edge
 
 Parameters:


### PR DESCRIPTION
- [x] add an optional `PermissionBoundaryPolicyArn` as variable, to be used as a boundary policy ARN for the organisations that need it
- [x] using `Globals` to avoid repeating the `PermissionsBoundary` setting in every single lambda 
- [x] saved privately in Centrica prod OTP account's [serverless application repository](https://serverlessrepo.aws.amazon.com/applications) for now
